### PR TITLE
cosign-ecs-function: fix module name to correct vanity import path

### DIFF
--- a/cosign-ecs-function/aws.go
+++ b/cosign-ecs-function/aws.go
@@ -3,13 +3,14 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
+	"os"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/sns"
-	"log"
-	"os"
 )
 
 type NotificationMessage struct {

--- a/cosign-ecs-function/cosign.go
+++ b/cosign-ecs-function/cosign.go
@@ -5,6 +5,9 @@ import (
 	"crypto"
 	"errors"
 	"fmt"
+	"log"
+	"os"
+
 	ecrlogin "github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
 	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -14,8 +17,6 @@ import (
 	ociremote "github.com/sigstore/cosign/pkg/oci/remote"
 	sigs "github.com/sigstore/cosign/pkg/signature"
 	sigstoresigs "github.com/sigstore/sigstore/pkg/signature"
-	"log"
-	"os"
 )
 
 func getKey(ctx context.Context, accountID, region string) (sigstoresigs.Verifier, error) {

--- a/cosign-ecs-function/go.mod
+++ b/cosign-ecs-function/go.mod
@@ -1,4 +1,4 @@
-module github.com/strongjz/cosign-ecs-verify/cosign-ecs-function
+module chainguard.dev/cosign-ecs-verify/cosign-ecs-function
 
 go 1.17
 

--- a/cosign-ecs-function/main.go
+++ b/cosign-ecs-function/main.go
@@ -1,4 +1,4 @@
-package main
+package main // import "chainguard.dev/cosign-ecs-verify/cosign-ecs-function"
 
 import (
 	"context"

--- a/cosign-ecs-function/main.go
+++ b/cosign-ecs-function/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"log"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
-	"log"
 )
 
 func handler(event events.CloudWatchEvent) {


### PR DESCRIPTION
Fix module name to correct vanity import path.

---

I don't know chainguard already has a vanity import path for `chainguard.dev/cosign-ecs-verify/cosign-ecs-function`.