### PR TITLE
cosign-ecs-function: fix module name to correct repository path

### DIFF
--- a/cosign-ecs-function/go.mod
+++ b/cosign-ecs-function/go.mod
@@ -1,4 +1,4 @@
-module github.com/strongjz/cosign-ecs-verify/cosign-ecs-function
+module github.com/chainguard-dev/cosign-ecs-verify/cosign-ecs-function
 
 go 1.17
 


### PR DESCRIPTION
Fix module name to correct repository path to `github.com/chainguard-dev/cosign-ecs-verify/cosign-ecs-function`.

In the discussion at #15, @znewman01 said:

> "I don't think I'm going to move this to chainguard.dev."

So, fix only of `cosign-ecs-function` packages module name.